### PR TITLE
Add Twelve Data exchange-rate provider

### DIFF
--- a/CurrencyConverterExtension/Converter/ConverterSettings.cs
+++ b/CurrencyConverterExtension/Converter/ConverterSettings.cs
@@ -50,14 +50,26 @@ public class ConverterSettings
                 {"ConversionFallbackLink", "https://api.frankfurter.dev/v2/rates?base={from}"},
                 {"ConversionHelperLink", "https://api.frankfurter.dev/v2/currencies"},
             }
+        },
+        {
+            "TwelveData", new()
+            {
+                {"ConversionLink", "https://api.twelvedata.com/exchange_rate?symbol={from}/{to}&apikey={api_key}"},
+                {"ConversionFallbackLink", "https://api.twelvedata.com/exchange_rate?symbol={from}/{to}&apikey={api_key}"},
+                {"ConversionHelperLink", "https://twelvedata.com/docs"},
+            }
         }
     };
 
     private bool UsesUppercaseCurrencyCodes =>
-        _settings.ConversionAPI is (int)ConverterSettingsApi.CurrencyAPI or (int)ConverterSettingsApi.Frankfurter;
+        _settings.ConversionAPI is (int)ConverterSettingsApi.CurrencyAPI
+            or (int)ConverterSettingsApi.Frankfurter
+            or (int)ConverterSettingsApi.TwelveData;
 
     private bool RequiresApiKey =>
-        _settings.ConversionAPI is (int)ConverterSettingsApi.ExchangeRateAPI or (int)ConverterSettingsApi.CurrencyAPI;
+        _settings.ConversionAPI is (int)ConverterSettingsApi.ExchangeRateAPI
+            or (int)ConverterSettingsApi.CurrencyAPI
+            or (int)ConverterSettingsApi.TwelveData;
 
     private string ParseLink(string link, string from, string to) => link
         .Replace("{api_key}", _settings.ConversionAPIKey)
@@ -181,4 +193,5 @@ public enum ConverterSettingsApi
     ExchangeRateAPI,
     CurrencyAPI,
     Frankfurter,
+    TwelveData,
 }

--- a/CurrencyConverterExtension/Converter/CurrencyConverter.cs
+++ b/CurrencyConverterExtension/Converter/CurrencyConverter.cs
@@ -368,6 +368,11 @@ internal sealed partial class CurrencyConverter : IDisposable
             return cached;
         }
 
+        if (_settings.ConversionAPI == (int)ConverterSettingsApi.TwelveData)
+        {
+            return await GetTwelveDataRateAsync(fromCurrency, toCurrency, cancellationToken).ConfigureAwait(false);
+        }
+
         // A successful populate stores every target for this base. A missing
         // pair after that is invalid — do not fetch the same JSON again.
         if (HasFreshRatesForBase(fromCurrency))
@@ -540,6 +545,40 @@ internal sealed partial class CurrencyConverter : IDisposable
 
         return (convertedAmount, precision);
     }
+
+    // ==================== Twelve Data BEGIN ====================
+    // Pair-based response parsing only; common validation, URL construction,
+    // HTTP/fallback handling and cache storage are reused.
+    // Remove this block plus the dispatch in GetConversionRateAsync to remove the provider.
+    private async Task<(decimal Rate, DateTime UpdatedAt)> GetTwelveDataRateAsync(
+        string fromCurrency,
+        string toCurrency,
+        CancellationToken cancellationToken)
+    {
+        _converterSettings.ValidateConversionAPI();
+
+        string targetCurrency = toCurrency.ToUpperInvariant();
+        string url = _converterSettings.GetConversionLink(fromCurrency, targetCurrency);
+        using HttpResponseMessage response = await GetWithFallbackAsync(
+            url,
+            fromCurrency,
+            targetCurrency,
+            cancellationToken).ConfigureAwait(false);
+
+        string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        using JsonDocument doc = JsonDocument.Parse(content);
+
+        if (!doc.RootElement.TryGetProperty("rate", out JsonElement rateElement)
+            || !rateElement.TryGetDecimal(out decimal rate))
+        {
+            throw new InvalidOperationException("Invalid Twelve Data response: missing 'rate'.");
+        }
+
+        DateTime fetchedAt = DateTime.UtcNow;
+        _conversionCache[(fromCurrency, toCurrency)] = (rate, fetchedAt);
+        return (rate, fetchedAt);
+    }
+    // ===================== Twelve Data END =====================
 
     internal void ValidateConversionAPI() => _converterSettings.ValidateConversionAPI();
 

--- a/CurrencyConverterExtension/Helpers/Settings/SettingsManager.cs
+++ b/CurrencyConverterExtension/Helpers/Settings/SettingsManager.cs
@@ -57,6 +57,7 @@ namespace CurrencyConverterExtension.Helpers
                 new(Resources.frankfurter_api, ((int)ConverterSettingsApi.Frankfurter).ToString(CultureInfo.InvariantCulture)),
                 new(Resources.exchange_rate_api, ((int)ConverterSettingsApi.ExchangeRateAPI).ToString(CultureInfo.InvariantCulture)),
                 new(Resources.currency_api, ((int)ConverterSettingsApi.CurrencyAPI).ToString(CultureInfo.InvariantCulture)),
+                new(Resources.twelve_data_api, ((int)ConverterSettingsApi.TwelveData).ToString(CultureInfo.InvariantCulture)),
             })
         { Value = ((int)ConverterSettingsApi.Default).ToString(CultureInfo.InvariantCulture) };
 

--- a/CurrencyConverterExtension/Properties/Resources.Designer.cs
+++ b/CurrencyConverterExtension/Properties/Resources.Designer.cs
@@ -205,6 +205,15 @@ namespace CurrencyConverterExtension.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Twelve Data.
+        /// </summary>
+        internal static string twelve_data_api {
+            get {
+                return ResourceManager.GetString("twelve_data_api", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Suppress fallback warnings.
         /// </summary>
         internal static string suppress_fallback_warnings {

--- a/CurrencyConverterExtension/Properties/Resources.resx
+++ b/CurrencyConverterExtension/Properties/Resources.resx
@@ -165,6 +165,9 @@
   <data name="local_currency_description" xml:space="preserve">
     <value>Set your local currency for quick conversion</value>
   </data>
+  <data name="twelve_data_api" xml:space="preserve">
+    <value>Twelve Data</value>
+  </data>
   <data name="suppress_fallback_warnings" xml:space="preserve">
     <value>Suppress fallback warnings</value>
   </data>

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Open Settings from the Currency Converter command (context menu → Settings).
 | **Decimal format separator**        | System default, always dots, or always commas              |
 | **Conversion Cache duration**       | How long rates stay cached, in hours (min `0.5`, max `24`) |
 | **Conversion API**                  | Rate provider (see below)                                  |
-| **Conversion API Key**              | Required only for ExchangeRateAPI or CurrencyAPI           |
+| **Conversion API Key**              | Required for ExchangeRateAPI, CurrencyAPI, or Twelve Data   |
 | **Suppress fallback warnings**      | On by default. Home-list conversion errors show **Convert "query" with Currency Converter** instead of a warning |
 
 ## Conversion API
@@ -190,6 +190,11 @@ This extension uses third-party APIs for the latest conversion rates:
    - Updated frequently throughout the day ([pricing](https://currencyapi.com/pricing/)).
    - See their documentation for update frequency, pricing, and supported features.
    - Requires an API key in Settings.
+
+5. **[Twelve Data](https://twelvedata.com/)**
+   - Uses the real-time `/exchange_rate` endpoint for supported forex and cryptocurrency pairs.
+   - Requires an API key in Settings.
+   - Pair responses are cached using the existing **Conversion Cache duration** setting.
 
 None of these APIs are affiliated with this extension. To use a different rate provider, or to suggest a new one, open a pull request.
 

--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ This extension uses third-party APIs for the latest conversion rates:
    - Requires an API key in Settings.
 
 5. **[Twelve Data](https://twelvedata.com/)**
-   - Uses the real-time `/exchange_rate` endpoint for supported forex and cryptocurrency pairs.
+   - Provides real-time exchange rates for supported forex and cryptocurrency pairs.
+   - Free tier: 8 API credits per minute, up to 800 per day ([pricing](https://twelvedata.com/pricing)).
    - Requires an API key in Settings.
-   - Pair responses are cached using the existing **Conversion Cache duration** setting.
 
 None of these APIs are affiliated with this extension. To use a different rate provider, or to suggest a new one, open a pull request.
 


### PR DESCRIPTION
Adds Twelve Data as a new conversion API option.

### Changes

* Add Twelve Data to the Conversion API setting.
* Fetch exchange rates through Twelve Data's `/exchange_rate` endpoint using currency pairs.
* Require an API key when Twelve Data is selected.
* Parse the returned `rate` value and store it in the existing conversion cache.
* Apply the configured Conversion Cache duration to Twelve Data rates.
* Add `Resources.twelve_data_api` for the provider name in settings.
* Add Twelve Data to the provider documentation in the README.

Twelve Data requests are made per currency pair because its /exchange_rate endpoint returns a single pair rate rather than a full base-currency rate table. Trying to emulate the existing full-table flow would require multiple API requests and unnecessarily increase API usage.

